### PR TITLE
Add sector and stock filtering modules

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,11 @@
+from typing import List, Dict
+
+
+def filter_by_sector(stocks: List[Dict], sector: str) -> List[Dict]:
+    """Return stocks that belong to the provided sector."""
+    return [s for s in stocks if s.get("sector") == sector]
+
+
+def filter_options_only(stocks: List[Dict]) -> List[Dict]:
+    """Return only stocks which have options contracts available."""
+    return [s for s in stocks if s.get("options")]

--- a/main.py
+++ b/main.py
@@ -2,11 +2,8 @@ from scanner import Scanner
 
 
 def main():
-    # Example watchlist
-    tickers = ["AAPL", "MSFT", "GOOGL"]
-    scanner = Scanner(tickers)
-    scanner.update_data()
-    results = scanner.scan()
+    scanner = Scanner()
+    results = scanner.scan(sector="Technology", options_only=True, limit=50)
     for res in results:
         print(
             f"{res['ticker']}: price={res['price']:.2f} RSI14={res['RSI14']:.2f} "

--- a/scanner.py
+++ b/scanner.py
@@ -1,49 +1,86 @@
-from typing import List
+from typing import List, Optional, Dict
 
 from data_collector import DataCollector
 from database import Database
 from analyzer import add_indicators, support_resistance
+from stock_list import load_stock_list
+from filters import filter_by_sector, filter_options_only
 
 
 class Scanner:
-    """Runs the overall scanning logic."""
+    """Runs the overall scanning logic with optional filtering."""
 
-    def __init__(self, tickers: List[str]):
-        self.tickers = tickers
-        self.collector = DataCollector(tickers)
+    def __init__(self, tickers: Optional[List[str]] = None):
+        self.tickers = tickers or []
         self.db = Database()
 
-    def update_data(self):
-        """Fetch and store fresh historical data."""
-        data = self.collector.fetch_historical()
+    def update_data(self, tickers: List[str]):
+        """Fetch and store fresh historical data for given tickers."""
+        collector = DataCollector(tickers)
+        data = collector.fetch_historical()
         for df in data.values():
             self.db.insert_dataframe(df)
 
-    def scan(self):
-        """Analyze tickers and print trading signals."""
+    def _select_tickers(
+        self,
+        sector: Optional[str] = None,
+        options_only: bool = False,
+        limit: Optional[int] = None,
+    ) -> List[str]:
+        stocks = load_stock_list()
+        if self.tickers:
+            stocks = [s for s in stocks if s["ticker"] in self.tickers]
+        if sector:
+            stocks = filter_by_sector(stocks, sector)
+        if options_only:
+            stocks = filter_options_only(stocks)
+        if limit:
+            stocks = stocks[:limit]
+        return [s["ticker"] for s in stocks]
+
+    def scan(
+        self,
+        sector: Optional[str] = None,
+        options_only: bool = False,
+        limit: Optional[int] = None,
+    ) -> List[Dict]:
+        """Analyze selected tickers and return trading signals."""
+        tickers = self._select_tickers(sector, options_only, limit)
+        if not tickers:
+            return []
+
+        self.update_data(tickers)
+
         results = []
-        for ticker in self.tickers:
+        for ticker in tickers:
             df = self.db.fetch_ticker(ticker)
             if df.empty:
                 continue
             df = add_indicators(df)
             levels = support_resistance(df)
             last = df.iloc[-1]
-            price = last['close']
-            if levels['support'] == 0 and levels['resistance'] == 0:
+            price = last["close"]
+            if levels["support"] == 0 and levels["resistance"] == 0:
                 continue
-            near_support = abs(price - levels['support']) / price < 0.02
-            near_resistance = abs(price - levels['resistance']) / price < 0.02
-            if last['RSI14'] > 70 or last['RSI14'] < 30 or near_support or near_resistance:
-                results.append({
-                    'ticker': ticker,
-                    'price': price,
-                    'RSI14': last['RSI14'],
-                    'support': levels['support'],
-                    'resistance': levels['resistance'],
-                    'near_support': near_support,
-                    'near_resistance': near_resistance
-                })
+            near_support = abs(price - levels["support"]) / price < 0.02
+            near_resistance = abs(price - levels["resistance"]) / price < 0.02
+            if (
+                last["RSI14"] > 70
+                or last["RSI14"] < 30
+                or near_support
+                or near_resistance
+            ):
+                results.append(
+                    {
+                        "ticker": ticker,
+                        "price": price,
+                        "RSI14": last["RSI14"],
+                        "support": levels["support"],
+                        "resistance": levels["resistance"],
+                        "near_support": near_support,
+                        "near_resistance": near_resistance,
+                    }
+                )
         return results
 
     def close(self):

--- a/sectors.py
+++ b/sectors.py
@@ -1,0 +1,12 @@
+import json
+from typing import List
+from pathlib import Path
+
+from stock_list import load_stock_list
+
+
+def get_all_sectors(path: str = "stocks.json") -> List[str]:
+    """Return a sorted list of all unique sectors from cached stock data."""
+    stocks = load_stock_list(path)
+    sectors = {stock.get("sector") for stock in stocks if stock.get("sector")}
+    return sorted(sectors)

--- a/stock_list.py
+++ b/stock_list.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+try:
+    import yfinance as yf
+except ImportError:  # pragma: no cover - yfinance may not be installed in tests
+    yf = None
+
+STOCKS_FILE = "stocks.json"
+
+
+def _fetch_tickers() -> List[str]:
+    """Gather a broad list of US tickers using yfinance helper functions."""
+    if yf is None:
+        return []
+
+    tickers = []
+    for func_name in [
+        "tickers_sp500",
+        "tickers_nasdaq",
+        "tickers_other",
+        "tickers_dow",
+        "tickers_ibovespa",  # broad coverage if available
+        "tickers_ftse100",
+        "tickers_nifty50",
+    ]:
+        func = getattr(yf, func_name, None)
+        if callable(func):
+            try:
+                tickers.extend(func())
+            except Exception:
+                pass
+    return sorted(set(tickers))
+
+
+def build_stock_list(path: str = STOCKS_FILE) -> List[Dict]:
+    """Fetch metadata for many US stocks and cache to a JSON file."""
+    if yf is None:
+        raise RuntimeError("yfinance is required to build the stock list")
+
+    tickers = _fetch_tickers()
+    stocks: List[Dict] = []
+    for t in tickers:
+        try:
+            ticker = yf.Ticker(t)
+            info = ticker.info or {}
+            options = bool(getattr(ticker, "options", []))
+            stocks.append(
+                {
+                    "ticker": t,
+                    "name": info.get("shortName") or info.get("longName"),
+                    "sector": info.get("sector"),
+                    "market_cap": info.get("marketCap"),
+                    "options": options,
+                }
+            )
+        except Exception:
+            # Skip tickers that cause issues
+            continue
+
+    with open(path, "w") as f:
+        json.dump(stocks, f)
+    return stocks
+
+
+def load_stock_list(path: str = STOCKS_FILE) -> List[Dict]:
+    """Load cached stock list; build it if missing."""
+    p = Path(path)
+    if p.exists():
+        try:
+            with p.open() as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return build_stock_list(path)


### PR DESCRIPTION
## Summary
- fetch and cache stock metadata in `stock_list.py`
- provide `sectors.py` helper to list sectors
- implement simple filtering utilities
- extend `Scanner` to filter by sector and options
- update CLI example in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686545e7332c8330a0a2d47d3f0a17bc