### PR TITLE
Improve indicator calculation robustness

### DIFF
--- a/business_opportunity_finder.py
+++ b/business_opportunity_finder.py
@@ -81,10 +81,16 @@ def _add_indicators(df: pd.DataFrame) -> pd.DataFrame:
 
     df = df.copy()
     df["RSI"] = ta.rsi(df["Close"], length=RSI_PERIOD)
-    df = df[~df.index.duplicated(keep='last')]  # remove duplicated timestamps
+    df = df[~df.index.duplicated(keep="last")]  # remove duplicated timestamps
     stoch = ta.stoch(df["High"], df["Low"], df["Close"], k=STOCH_K, d=STOCH_D)
-    df["STOCHk"] = stoch[f"STOCHk_{STOCH_K}_{STOCH_D}_{STOCH_D}"]
-    df["STOCHd"] = stoch[f"STOCHd_{STOCH_K}_{STOCH_D}_{STOCH_D}"]
+    if stoch is None or stoch.empty:
+        df["STOCHk"] = pd.NA
+        df["STOCHd"] = pd.NA
+    else:
+        k_col = stoch.columns[0]
+        d_col = stoch.columns[1] if len(stoch.columns) > 1 else stoch.columns[0]
+        df["STOCHk"] = stoch[k_col]
+        df["STOCHd"] = stoch[d_col]
     return df
 
 


### PR DESCRIPTION
## Summary
- handle cases where `pandas_ta.stoch` returns an empty dataframe

## Testing
- `python -m py_compile business_opportunity_finder.py`

------
https://chatgpt.com/codex/tasks/task_e_6865569506dc83309cf215089d31a275