### PR TITLE
Add volume/price filtering and GPT analysis

### DIFF
--- a/ask_ai.py
+++ b/ask_ai.py
@@ -1,0 +1,54 @@
+import os
+from typing import List, Dict, Any
+
+import openai
+from tabulate import tabulate
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def ask_gpt_about_opportunities(opportunities: List[Dict[str, Any]]) -> str:
+    """Uses OpenAI ChatGPT to analyze the opportunity list and return trade suggestions."""
+    table_data = []
+    for row in opportunities:
+        ticker = row.get("ticker")
+        if isinstance(ticker, dict):
+            ticker = ticker.get("ticker")
+        price = row.get("price")
+        table_data.append(
+            [
+                ticker,
+                f"{row.get('rsi', 0):.2f}",
+                f"{row.get('stoch_k', 0):.2f}",
+                f"{row.get('stoch_d', 0):.2f}",
+                f"{price:.2f}" if isinstance(price, (int, float)) else "",
+                f"{row.get('support', 0):.2f}",
+                f"{row.get('resistance', 0):.2f}",
+            ]
+        )
+    headers = ["Ticker", "RSI", "Stoch %K", "Stoch %D", "Price", "Support", "Resistance"]
+    table = tabulate(table_data, headers=headers, tablefmt="github")
+
+    prompt = (
+        "Given the following technical indicators, which stocks would you recommend trading today? "
+        "Please explain why.\n\n" + table
+    )
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"].strip()
+
+
+if __name__ == "__main__":
+    from business_opportunity_finder import find_opportunities
+    from stock_list import load_stock_list
+
+    ops = find_opportunities(load_stock_list())
+    if not ops:
+        print("No opportunities found.")
+    else:
+        answer = ask_gpt_about_opportunities(ops)
+        print(answer)
+

--- a/business_opportunity_finder.py
+++ b/business_opportunity_finder.py
@@ -108,7 +108,13 @@ def _support_resistance(df: pd.DataFrame, lookback: int = LOOKBACK_SUPPORT) -> D
 
 # Public API
 
-def find_opportunities(tickers: List[str], mode: str = "both") -> List[Dict[str, object]]:
+def find_opportunities(
+    tickers: List[str],
+    mode: str = "both",
+    min_volume: int = 0,
+    min_price: float = 0.0,
+    max_price: float = float("inf"),
+) -> List[Dict[str, object]]:
     """Scan tickers for overbought or oversold conditions.
 
     Parameters
@@ -117,6 +123,12 @@ def find_opportunities(tickers: List[str], mode: str = "both") -> List[Dict[str,
         Symbols to scan.
     mode : str, optional
         'overbought', 'oversold', or 'both'. Defaults to 'both'.
+    min_volume : int, optional
+        Skip tickers with volume below this value.
+    min_price : float, optional
+        Skip tickers with a closing price below this value.
+    max_price : float, optional
+        Skip tickers with a closing price above this value.
 
     Returns
     -------
@@ -138,7 +150,18 @@ def find_opportunities(tickers: List[str], mode: str = "both") -> List[Dict[str,
 
 
         df = _add_indicators(df)
-        indicators = df.iloc[-1]
+        last_row = df.iloc[-1]
+
+        try:
+            volume_val = float(last_row["Volume"])
+            price_val = float(last_row["Close"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        if volume_val < min_volume or price_val < min_price or price_val > max_price:
+            continue
+
+        indicators = last_row
         try:
             rsi_val = float(indicators["RSI"])
             stoch_k = float(indicators["STOCHk"])
@@ -166,6 +189,7 @@ def find_opportunities(tickers: List[str], mode: str = "both") -> List[Dict[str,
         results.append(
             {
                 "ticker": ticker,
+                "price": price_val,
                 "rsi": rsi_val,
                 "stoch_k": stoch_k,
                 "stoch_d": stoch_d,


### PR DESCRIPTION
## Summary
- add min_volume, min_price and max_price filters when finding opportunities
- include price in results
- provide ask_ai.py helper to query ChatGPT about opportunities

## Testing
- `python -m py_compile business_opportunity_finder.py ask_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_6865605951d88330a08c941f3351d65d